### PR TITLE
feature // Add support to deploy KMS as a SOPs keystore to encrypt/decrypt secrets

### DIFF
--- a/kms.tf
+++ b/kms.tf
@@ -1,0 +1,86 @@
+resource "aws_kms_key" "this" {
+  count               = var.flux_sops_kms_create ? 1 : 0
+  description         = "${var.flux_sops_kms_name} key"
+  enable_key_rotation = true
+  key_usage           = "ENCRYPT_DECRYPT"
+}
+
+resource "aws_kms_grant" "grants-rw" {
+  count             = length(var.flux_sops_kms_additional_principals_rw)
+  grantee_principal = var.flux_sops_kms_additional_principals_rw[count.index]
+  key_id            = aws_kms_key.this.key_id
+  operations        = ["Decrypt", "Encrypt"]
+}
+
+resource "aws_kms_grant" "grants-ro" {
+  count             = length(var.flux_sops_kms_additional_principals_ro)
+  grantee_principal = var.flux_sops_kms_additional_principals_ro[count.index]
+  key_id            = aws_kms_key.this.key_id
+  operations        = ["Decrypt"]
+}
+
+resource "aws_kms_alias" "this" {
+  count         = var.flux_sops_kms_create ? 1 : 0
+  name          = "alias/${var.flux_sops_kms_name}"
+  target_key_id = aws_kms_key.this.key_id
+}
+
+data "aws_iam_policy_document" "flux2_kms_sts" {
+
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+
+    }
+    principals {
+      type        = "Federated"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.this.id}:oidc-provider/${local.oidc_id}"]
+
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_id}:aud"
+      values = [
+        "sts.amazonaws.com"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "flux2_kms_role" {
+  count              = var.flux_sops_kms_create ? 1 : 0
+  name               = "${var.flux_sops_kms_name}-flux2_sts"
+  assume_role_policy = data.aws_iam_policy_document.flux2_kms_sts.json
+}
+
+resource "aws_iam_policy" "flux2_kms_ro" {
+  count       = var.flux_sops_kms_create ? 1 : 0
+  name_prefix = "${var.flux_sops_kms_name}-flux2_ro"
+  policy      = data.aws_iam_policy_document.flux2_kms_ro.json
+}
+
+resource "aws_iam_policy" "flux2_kms_rw" {
+  count       = var.flux_sops_kms_create ? 1 : 0
+  name_prefix = "${var.flux_sops_kms_name}-flux2_rw"
+  policy      = data.aws_iam_policy_document.flux2_kms_rw.json
+}
+
+data "aws_iam_policy_document" "flux2_kms_rw" {
+  statement {
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+    resources = [
+      aws_kms_key.this.arn,
+    ]
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -56,6 +56,27 @@ resource "kubectl_manifest" "install" {
   yaml_body  = each.value
 }
 
+// Note: Workaround unless support for adding the IRSA ARN is added to the flux2 provider: https://github.com/fluxcd/terraform-provider-flux/issues/120. We are removing the kustomize SA from the collection of 
+resource "kubectl_manifest" "apply" {
+  for_each   = { for v in data.kustomization_overlay.example.manifests : lower(join("/", compact([v.data.apiVersion, v.data.kind, lookup(v.data.metadata, "namespace", ""), v.data.metadata.name]))) => v.content if anytrue([v.data.kind != "ServiceAccount", v.data.metadata.name != "kustomize-controller"]) }
+  depends_on = [kubernetes_namespace.flux_system]
+  yaml_body  = each.value
+}
+
+resource "kubernetes_service_account" "kustomize_controller" {
+  metadata {
+    name      = "kustomize-controller"
+    namespace = "flux-system"
+    labels = {
+      "app.kubernetes.io/instance" = "flux-system"
+      "app.kubernetes.io/part-of"  = "flux"
+      "app.kubernetes.io/version"  = data.install.main.version
+    }
+    annotations = {
+      "eks.amazonaws.com/role-arn" = var.flux_sops_kms_create ? aws_kms_key.this.arn : ""
+    }
+  }
+}
 
 // The group of manifests to initialize the flux state repo
 resource "kubectl_manifest" "sync" {

--- a/variables.tf
+++ b/variables.tf
@@ -37,3 +37,25 @@ variable "flux_ssh_known_hosts" {
   default     = "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="
   description = "SSH known hosts used to access private helm repos via git SSH. See https://github.com/fluxcd/helm-operator/blob/master/chart/helm-operator/README.md#use-a-private-git-server"
 }
+
+variable "flux_sops_kms_create" {
+  type        = bool
+  default     = false
+  description = "Optional: Deploy KMS resource which will act as the key store for SOP encrypted secrets. See: (https://toolkit.fluxcd.io/guides/mozilla-sops/)"
+}
+
+variable "flux_sops_kms_name" {
+  type        = string
+  default     = "flux2"
+  description = "Optional: The name of the KMS store"
+}
+
+variable "flux_sops_kms_additional_principals_rw" {
+  type        = set(string)
+  description = "Optional: Users to grant management access to the KMS store"
+}
+
+variable "flux_sops_kms_additional_principals_ro" {
+  type        = set(string)
+  description = "Optional: Users to grant readonly access to the KMS store"
+}


### PR DESCRIPTION
Flux2 supports using Mozilla SOPs, in order to decrypt secret files via KMS, allowing Secrets to be stored in GitHub. See: https://toolkit.fluxcd.io/guides/mozilla-sops/#aws