### PR TITLE
Feature // Add optional support for deploying the image automation controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ module "flux2-bootstrap" {
   flux_git_branch      = "main"
   flux_ssh_known_hosts = "your.private.git.server.io ssh-rsa AAAAB...."
   flux_sync_interval   = "5m"
+  flux_deploy_image_automation = true
 }
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 # Generate manifests
 data "flux_install" "main" {
   target_path = var.flux_git_path
-  components_extra = var.flux_deploy_image_automation ? ["image-automation-controller"] : []
+  components_extra = var.flux_deploy_image_automation ? ["image-automation-controller", "image-reflector-controller"] : []
 }
 
 data "flux_sync" "main" {

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 # Generate manifests
 data "flux_install" "main" {
   target_path = var.flux_git_path
+  components_extra = var.flux_deploy_image_automation ? ["image-automation-controller"] : []
 }
 
 data "flux_sync" "main" {

--- a/variables.tf
+++ b/variables.tf
@@ -37,3 +37,9 @@ variable "flux_ssh_known_hosts" {
   default     = "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="
   description = "SSH known hosts used to access private helm repos via git SSH. See https://github.com/fluxcd/helm-operator/blob/master/chart/helm-operator/README.md#use-a-private-git-server"
 }
+
+variable "flux_deploy_image_automation" {
+  type        = bool
+  default     = false
+  description = "Optionally deploy the image automation controller with the gitops toolkit"
+}


### PR DESCRIPTION
Optional flag to enable the [image automation controller](https://fluxcd.io/docs/components/image/) with the flux2 deployment